### PR TITLE
Some performance optimnizations in IRI module

### DIFF
--- a/lib/rdf/model/iri.ex
+++ b/lib/rdf/model/iri.ex
@@ -70,7 +70,7 @@ defmodule RDF.IRI do
   """
   @spec new!(coercible) :: t
   def new!(iri)
-  def new!(iri) when is_binary(iri), do: iri |> valid!() |> new()
+  def new!(iri) when is_binary(iri), do: iri |> valid_binary!() |> new()
   # since terms of a namespace are already validated
   def new!(term) when maybe_ns_term(term), do: new(term)
   def new!(%URI{} = uri), do: uri |> valid!() |> new()
@@ -139,6 +139,11 @@ defmodule RDF.IRI do
     iri
   end
 
+  defp valid_binary!(iri) do
+    if not valid_binary?(iri), do: raise(RDF.IRI.InvalidError, "Invalid IRI: #{inspect(iri)}")
+    iri
+  end
+
   @doc """
   Checks if the given IRI is valid.
 
@@ -155,6 +160,9 @@ defmodule RDF.IRI do
   # TODO: Provide a more elaborate validation
   def valid?(iri), do: absolute?(iri)
 
+  @spec valid_binary?(binary()) :: boolean
+  defp valid_binary?(iri), do: not is_nil(scheme_from_binary(iri))
+
   @doc """
   Checks if the given value is an absolute IRI.
 
@@ -164,7 +172,7 @@ defmodule RDF.IRI do
   @spec absolute?(any) :: boolean
   def absolute?(iri)
 
-  def absolute?(value) when is_binary(value), do: not is_nil(scheme(value))
+  def absolute?(value) when is_binary(value), do: not is_nil(scheme_from_binary(value))
   def absolute?(%__MODULE__{value: value}), do: absolute?(value)
   def absolute?(%URI{scheme: nil}), do: false
   def absolute?(%URI{scheme: _}), do: true
@@ -231,8 +239,12 @@ defmodule RDF.IRI do
   def scheme(%URI{scheme: scheme}), do: scheme
   def scheme(term) when maybe_ns_term(term), do: Namespace.resolve_term!(term) |> scheme()
 
-  def scheme(iri) when is_binary(iri) do
-    with [_, scheme] <- Regex.run(@scheme_regex, iri) do
+  def scheme(iri) when is_binary(iri), do: scheme_from_binary(iri)
+
+  # specialized internal version if we already know the type of the iri. this avoids
+  # having to thread through multiple stages of pattern matching
+  defp scheme_from_binary(iri) do
+    with [_, scheme] <- RDF.Util.Regex.run(@scheme_regex, iri) do
       scheme
     end
   end

--- a/lib/rdf/model/iri.ex
+++ b/lib/rdf/model/iri.ex
@@ -241,8 +241,6 @@ defmodule RDF.IRI do
 
   def scheme(iri) when is_binary(iri), do: scheme_from_binary(iri)
 
-  # specialized internal version if we already know the type of the iri. this avoids
-  # having to thread through multiple stages of pattern matching
   defp scheme_from_binary(iri) do
     with [_, scheme] <- RDF.Util.Regex.run(@scheme_regex, iri) do
       scheme

--- a/lib/rdf/model/statement.ex
+++ b/lib/rdf/model/statement.ex
@@ -163,7 +163,7 @@ defmodule RDF.Statement do
   def coerce_graph_name(%IRI{} = iri), do: iri
   def coerce_graph_name(%BlankNode{} = bnode), do: bnode
   def coerce_graph_name("_:" <> identifier), do: BlankNode.new(identifier)
-  def coerce_graph_name(iri) when maybe_ns_term(iri) or is_binary(iri), do: IRI.new!(iri)
+  def coerce_graph_name(iri) when is_binary(iri) or maybe_ns_term(iri), do: IRI.new!(iri)
 
   def coerce_graph_name(arg),
     do: raise(RDF.Quad.InvalidGraphContextError, graph_context: arg)

--- a/lib/rdf/model/statement.ex
+++ b/lib/rdf/model/statement.ex
@@ -122,7 +122,7 @@ defmodule RDF.Statement do
   def coerce_subject(%IRI{} = iri), do: iri
   def coerce_subject(%BlankNode{} = bnode), do: bnode
   def coerce_subject("_:" <> identifier), do: BlankNode.new(identifier)
-  def coerce_subject(iri) when maybe_ns_term(iri) or is_binary(iri), do: IRI.new!(iri)
+  def coerce_subject(iri) when is_binary(iri) or maybe_ns_term(iri), do: IRI.new!(iri)
   def coerce_subject(arg), do: raise(RDF.Triple.InvalidSubjectError, subject: arg)
 
   @doc false
@@ -133,7 +133,7 @@ defmodule RDF.Statement do
   # them, by introducing the notion of "generalized RDF".
   # TODO: Support an option `:strict_rdf` to explicitly disallow them or produce warnings or ...
   def coerce_predicate(%BlankNode{} = bnode), do: bnode
-  def coerce_predicate(iri) when maybe_ns_term(iri) or is_binary(iri), do: IRI.new!(iri)
+  def coerce_predicate(iri) when is_binary(iri) or maybe_ns_term(iri), do: IRI.new!(iri)
   def coerce_predicate(arg), do: raise(RDF.Triple.InvalidPredicateError, predicate: arg)
 
   @doc false

--- a/lib/rdf/utils/regex.ex
+++ b/lib/rdf/utils/regex.ex
@@ -14,7 +14,7 @@ defmodule RDF.Util.Regex do
   and always returns the matched binaries
   """
   @spec run(Regex.t(), binary()) :: nil | [binary]
-  if Application.compile_env(:rdf, :optizations, false) do
+  if Application.compile_env(:rdf, :optimize_regexes, false) do
     def run(%Regex{re_pattern: pattern}, string) do
       case :re.run(string, pattern, [{:capture, :all, :binary}]) do
         {:match, matches} -> matches

--- a/lib/rdf/utils/regex.ex
+++ b/lib/rdf/utils/regex.ex
@@ -5,7 +5,7 @@ defmodule RDF.Util.Regex do
   run of a comppiled regex, to check if the pcre version of the regex matches the
   version that the local OTP version got compiled against. This check seems to
   be unexpectedly costly (there is acall though to :erlang.system_info/1). It
-  seems worth it performance wise to curcumvent elixir here, and call trough to 
+  seems worth it performance wise to circumvent elixir here, and call through to 
   erlang 're' in this case.
   """
 

--- a/lib/rdf/utils/regex.ex
+++ b/lib/rdf/utils/regex.ex
@@ -14,11 +14,17 @@ defmodule RDF.Util.Regex do
   and always returns the matched binaries
   """
   @spec run(Regex.t(), binary()) :: nil | [binary]
-  def run(%Regex{re_pattern: pattern}, string) do
-    case :re.run(string, pattern, [{:capture, :all, :binary}]) do
-      {:match, matches} -> matches
-      :nomatch -> nil
-      :match -> []
+  if Application.compile_env(:rdf, :optizations, false) do
+    def run(%Regex{re_pattern: pattern}, string) do
+      case :re.run(string, pattern, [{:capture, :all, :binary}]) do
+        {:match, matches} -> matches
+        :nomatch -> nil
+        :match -> []
+      end
+    end
+  else
+    def run(%Regex{} = re, string) do
+      Regex.run(re, string)
     end
   end
 end

--- a/lib/rdf/utils/regex.ex
+++ b/lib/rdf/utils/regex.ex
@@ -2,7 +2,7 @@ defmodule RDF.Util.Regex do
   @moduledoc """
   Some of the regular expressions in the code base get executed in quote tight
   loops, sometimes millions of times. The elixir code base does a check on every
-  run of a comppiled regex, to check if the pcre version of the regex matches the
+  run of a compiled regex, to check if the pcre version of the regex matches the
   version that the local OTP version got compiled against. This check seems to
   be unexpectedly costly (there is acall though to :erlang.system_info/1). It
   seems worth it performance wise to circumvent elixir here, and call through to 

--- a/lib/rdf/utils/regex.ex
+++ b/lib/rdf/utils/regex.ex
@@ -1,0 +1,24 @@
+defmodule RDF.Util.Regex do
+  @moduledoc """
+  Some of the regular expressions in the code base get executed in quote tight
+  loops, sometimes millions of times. The elixir code base does a check on every
+  run of a comppiled regex, to check if the pcre version of the regex matches the
+  version that the local OTP version got compiled against. This check seems to
+  be unexpectedly costly (there is acall though to :erlang.system_info/1). It
+  seems worth it performance wise to curcumvent elixir here, and call trough to 
+  erlang 're' in this case.
+  """
+
+  @doc """
+  Replaces the elixir regex run function. It only works with compiled regexes,
+  and always returns the matched binaries
+  """
+  @spec run(Regex.t(), binary()) :: nil | [binary]
+  def run(%Regex{re_pattern: pattern}, string) do
+    case :re.run(string, pattern, [{:capture, :all, :binary}]) do
+      {:match, matches} -> matches
+      :nomatch -> nil
+      :match -> []
+    end
+  end
+end


### PR DESCRIPTION
This PR optimises the IRI module in some ways, that is relevant for very big files (i.e. where these functions get run quite often). The test case for this was a 30mb RDF file.

* Use :re.run directly, to avoid cost of Regex.run, which does a couple of calls to Keyword.get, and a call into the erlang library to figure out the PCRE version of the VM.
* Provide an optimized path when it's known that an IRI is getting constructed from a binary. This optimizes having to call through multiple functions that do the same pattern matches, since their public functions, and need to do this. In the future it might be preferable to avoid to_iri/from_binary calls for optimised construction
*  Reorders a guard expression for slight gain in performance

Open for debate of course. As I say. it might be better to provide explicit from_binary, from_uri, etc methods. 

I think both points could be applied to the entire code base as well. I didn't touch the XSD modules for example, and I saw that matches for binaries, etc. happen quite often in the entire call chain.